### PR TITLE
cache node layer

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -24,6 +24,7 @@ else
   rm -rf $layersdir/nodejs/*
 
   echo "cache = true" > $layersdir/nodejs.toml
+  echo "build = true" >> $layersdir/nodejs.toml
   echo "launch = true" >> $layersdir/nodejs.toml
   echo -e "[metadata]\nversion = \"$node_version\"" >> $layersdir/nodejs.toml
 


### PR DESCRIPTION
## Includes
- caching node on initial build
- setting a node version (`10.16.0`) in initial build
- if node version cached matches node version of the current build, it skips download and uses node from cache
- if node version cached does not match node version of current build, it removes the files from cache and downloads a new node

### GUS
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000006OuVwIAK/view