### PR TITLE
use yarn version from resolver

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -64,10 +64,12 @@ install_or_reuse_yarn() {
 
   if [[ $yarn_version == null ]]; then yarn_version="latest"; fi
 
-  local yarn_url=$(rv yarn $yarn_version)
+  local resolved_data=$(resolve-version yarn $yarn_version)
+  local yarn_url=$(echo $resolved_data | cut -f2 -d " ")
+  yarn_version=$(echo $resolved_data | cut -f1 -d " ")
 
   if $use_yarn; then
-    if [[ $yarn_url == $([[ -f $layers_dir/yarn.toml ]] && cat $layers_dir/yarn.toml | yj -t | jq -r .metadata.url) ]]; then
+    if [[ $yarn_version == $([[ -f $layers_dir/yarn.toml ]] && cat $layers_dir/yarn.toml | yj -t | jq -r .metadata.version) ]]; then
       echo "---> Reusing yarn@$yarn_version"
     else
       echo "---> Installing yarn@$yarn_version"
@@ -78,7 +80,7 @@ install_or_reuse_yarn() {
       echo "cache = true" > $layers_dir/yarn.toml
       echo "build = true" >> $layers_dir/yarn.toml
       echo "launch = true" >> $layers_dir/yarn.toml
-      echo -e "[metadata]\nurl = \"$yarn_url\"" >> $layers_dir/yarn.toml
+      echo -e "[metadata]\nversion = \"$yarn_version\"" >> $layers_dir/yarn.toml
 
       wget -qO - $yarn_url | tar xzf - -C $layers_dir/yarn
       mv $layers_dir/yarn/*/* $layers_dir/yarn


### PR DESCRIPTION
This lets the build step read the `yarn` version from `package.json` under the `.engines.yarn` keys.  

### Includes:
- query `package.json` for yarn version
- uses yarn version to create a url from nodebin
- caches the url in the `yarn.toml` metadata to match for future images