### PR TITLE
add version to resolve-version output

### DIFF
--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -78,7 +78,7 @@ func resolve(binary string, versionRequirement string) {
 			os.Exit(1)
 		}
 		if result.matched {
-			fmt.Printf("%s\n", result.release.url)
+			fmt.Printf("%s %s\n", result.release.version.String(), result.release.url)
 		} else {
 			fmt.Println("No result")
 			os.Exit(1)
@@ -95,7 +95,7 @@ func resolve(binary string, versionRequirement string) {
 			os.Exit(1)
 		}
 		if result.matched {
-			fmt.Printf("%s\n", result.release.url)
+			fmt.Printf("%s %s\n", result.release.version.String(), result.release.url)
 		} else {
 			fmt.Println("No result")
 			os.Exit(1)


### PR DESCRIPTION
Outputs the version with the url, so the url can be used for the build logs and used to cache the resolved Node and yarn versions in the `yarn.toml` and `nodejs.toml`.