### PR TITLE
update api version to 0.2

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,9 +1,9 @@
-# Buildpack ID and metadata
+api = "0.2"
+
 [buildpack]
 id = "heroku/nodejs-engine-buildpack"
-version = "0.0.1"
 name = "Node Buildpack"
+version = "0.0.1"
 
-# Stacks that the buildpack will work with
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
Adding the API version to the `buildpack.toml` file since it defaults to 0.1 (and new version needs to be used for next iteration of lifecycle).

More info here: https://buildpacks.io/docs/reference/buildpack-api/