### PR TITLE
Fix updates to nodejs.toml when layer contents not updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tgz
 bin/resolve-version
+
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Fixed
+- Fix updates to `nodejs.toml` when layer contents not updated ([#27](https://github.com/heroku/nodejs-engine-buildpack/pull/27))
 
 ## 0.4.0 (2019-10-31)
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -24,7 +24,7 @@ export PATH=$layers_dir/toolbox/bin:$PATH
 install_or_reuse_node "$layers_dir/nodejs" "$build_dir"
 export PATH=$layers_dir/nodejs/bin:$PATH
 
-parse_package_json_engines "$layers_dir/nodejs" "$build_dir"
+parse_package_json_engines "$layers_dir/package_manager_metadata" "$build_dir"
 
 if [[ -f "yarn.lock" ]]; then
 	install_or_reuse_yarn "$layers_dir/yarn" "$build_dir"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "heroku/nodejs-engine-buildpack"
 name = "Node Buildpack"
-version = "0.4.0"
+version = "0.4.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -153,12 +153,12 @@ write_launch_toml() {
 
   local command
 
-  if [[ -f "$build_dir/index.js" ]]; then
-    command="node index.js"
-  fi
-
   if [[ -f "$build_dir/server.js" ]]; then
     command="node server.js"
+  fi
+
+  if [[ -f "$build_dir/index.js" ]]; then
+    command="node index.js"
   fi
 
   if [[ ! $command ]]; then

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -89,6 +89,8 @@ parse_package_json_engines() {
   local resolved_data
   local yarn_url
 
+  echo "---> Parsing package.json"
+
   engine_npm=$(json_get_key "$build_dir/package.json" ".engines.npm")
   engine_yarn=$(json_get_key "$build_dir/package.json" ".engines.yarn")
 
@@ -98,11 +100,16 @@ parse_package_json_engines() {
   yarn_url=$(echo "$resolved_data" | cut -f2 -d " ")
   yarn_version=$(echo "$resolved_data" | cut -f1 -d " ")
 
-  {
-    echo "npm_version = \"$npm_version\""
-    echo "yarn_url = \"$yarn_url\""
-    echo "yarn_version = \"$yarn_version\""
-  } >> "${layer_dir}.toml"
+  cat << TOML > "${layer_dir}.toml"
+cache = false
+build = true
+launch = false
+
+[metadata]
+npm_version = "$npm_version"
+yarn_url = "$yarn_url"
+yarn_version = "$yarn_version"
+TOML
 }
 
 install_or_reuse_yarn() {

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -24,13 +24,13 @@ install_or_reuse_toolbox() {
   mkdir -p "${layer_dir}/bin"
 
   if [[ ! -f "${layer_dir}/bin/jq" ]]; then
-    echo "jq"
+    echo "- jq"
     curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > "${layer_dir}/bin/jq" \
       && chmod +x "${layer_dir}/bin/jq"
   fi
 
   if [[ ! -f "${layer_dir}/bin/yj" ]]; then
-    echo "yj"
+    echo "- yj"
     curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux > "${layer_dir}/bin/yj" \
       && chmod +x "${layer_dir}/bin/yj"
   fi

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -46,14 +46,14 @@ describe "lib/build.sh"
     export PATH=$layers_dir/toolbox/bin:$PATH
 
     it "creates a toolbox layer"
-      install_or_reuse_toolbox "$layers_dir/toolbox" $project_dir
+      install_or_reuse_toolbox "$layers_dir/toolbox"
 
       assert file_present "$layers_dir/toolbox/bin/jq"
       assert file_present "$layers_dir/toolbox/bin/yj"
     end
 
     it "creates a toolbox.toml"
-      install_or_reuse_toolbox "$layers_dir/toolbox" $project_dir
+      install_or_reuse_toolbox "$layers_dir/toolbox"
 
       assert file_present "$layers_dir/toolbox.toml"
     end
@@ -80,19 +80,19 @@ describe "lib/build.sh"
   describe "parse_package_json_engines"
     layers_dir=$(create_temp_layer_dir)
 
-    echo -e "[metadata]\n" > "${layers_dir}/nodejs.toml"
+    echo -e "[metadata]\n" > "${layers_dir}/package_manager_metadata.toml"
     create_temp_package_json
 
-    parse_package_json_engines "$layers_dir/nodejs" "tmp"
+    parse_package_json_engines "$layers_dir/package_manager_metadata" "tmp"
 
     it "writes npm version to layers/node.toml"
-      local npm_version=$(toml_get_key_from_metadata "$layers_dir/nodejs.toml" "npm_version")
+      local npm_version=$(toml_get_key_from_metadata "$layers_dir/package_manager_metadata.toml" "npm_version")
 
       assert equal "6.9.1" "$npm_version"
     end
 
     it "writes yarn_version to layers/node.toml"
-      local yarn_version=$(toml_get_key_from_metadata "$layers_dir/nodejs.toml" "yarn_version")
+      local yarn_version=$(toml_get_key_from_metadata "$layers_dir/package_manager_metadata.toml" "yarn_version")
 
       assert equal "1.19.1" "$yarn_version"
     end


### PR DESCRIPTION
## Problem
When the npm/yarn metadata is written to Node layer, the layer may not update Node and therefore subsequent buildpacks do not receive the layer correctly for use (ie. when running npm scripts).

## Fix
Creates a new layer to add npm/yarn metadata, so that it can be used in subsequent buildpacks.