### PR TITLE
Remove -buildpack from buildpack id

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.2"
 
 [buildpack]
-id = "heroku/nodejs-engine-buildpack"
+id = "heroku/nodejs-engine"
 name = "Node Buildpack"
 version = "0.4.1"
 


### PR DESCRIPTION
The "buildpack" is implied in all contexts (i.e. we don't publish this to a generic registry like NPM).