### PR TITLE
[[provide]] node in build plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master
 
+## 0.4.2 (2020-01-30)
+### Added
+- Added `provides` and `requires` of `node` to buildplan. ([#31](https://github.com/heroku/nodejs-engine-buildpack/pull/31))
+
 ## 0.4.1 (2019-11-08)
 ### Fixed
 - Fix updates to `nodejs.toml` when layer contents not updated ([#27](https://github.com/heroku/nodejs-engine-buildpack/pull/27))

--- a/bin/detect
+++ b/bin/detect
@@ -13,8 +13,5 @@ source "$bp_dir/lib/detect.sh"
 if ! detect_package_json "$build_dir" ; then
   exit 100
 else
-  cat << EOF > "$build_plan"
-  [[provides]]
-  name = "node"
-EOF
+  write_to_build_plan "$build_plan"
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -5,10 +5,16 @@ set -eo pipefail
 # shellcheck disable=SC2128
 bp_dir=$(cd "$(dirname "$0")/.."; pwd)
 build_dir=$(pwd)
+build_plan="$2"
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
 if ! detect_package_json "$build_dir" ; then
   exit 100
+else
+  cat << EOF > "$build_plan"
+  [[provides]]
+  name = "node"
+EOF
 fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "heroku/nodejs-engine"
 name = "Node Buildpack"
-version = "0.4.1"
+version = "0.4.2"
 
 [[stacks]]
 id = "heroku-18"

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -4,3 +4,14 @@ detect_package_json() {
   local build_dir=$1
   [[ -f "$build_dir/package.json" ]]
 }
+
+write_to_build_plan() {
+  local build_plan=$1
+  cat << EOF > "$build_plan"
+  [[provides]]
+  name = "node"
+
+  [[requires]]
+  name = "node"
+EOF
+}

--- a/shpec/detect_shpec.sh
+++ b/shpec/detect_shpec.sh
@@ -29,4 +29,22 @@ describe "lib/detect.sh"
       assert equal "$?" 0
     end
   end
+
+  describe "write_to_build_plan"
+    it "writes node for [[provides]] and [[requires]]"
+      project_dir=$(create_temp_project_dir)
+      touch "$project_dir/buildplan.toml"
+      write_to_build_plan "$project_dir/buildplan.toml"
+      actual=`cat $project_dir/buildplan.toml`
+      echo $actual
+      expected=`cat <<EOF
+  [[provides]]
+  name = "node"
+
+  [[requires]]
+  name = "node"
+EOF`
+      assert equal "$actual" "$expected"
+    end
+  end
 end


### PR DESCRIPTION
Ensure that the buildpack defines what it provides so that other buildpacks that depend on this buildpack can specify that requirement. The reason `node` was chosen was to align with the name that the riff node buildpack uses to require `node`.

https://github.com/buildpacks/spec/blob/master/buildpack.md#process
https://github.com/projectriff/node-function-buildpack/blob/07eacdbe9fe49b8ce8f726fc617a5bc895b9a7b4/node/buildpack.go#L72