### PR TITLE
Remove catching of unbound variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master
 
+## 0.4.3 (2020-02-24)
+### Fixed
+- Remove catching of unbound variables in `lib/build.sh` ([#36](https://github.com/heroku/nodejs-engine-buildpack/pull/36))
+
 ## 0.4.2 (2020-01-30)
 ### Added
 - Write bootstrapped binaries to a layer instead of to `bin`; Add a logging method for build output ([#34](https://github.com/heroku/nodejs-engine-buildpack/pull/34))

--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -e
 set -o pipefail
 
 layers_dir=$1

--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -37,6 +37,7 @@ create_bootstrap_layer() {
 
 bootstrap_buildpack() {
   local layer_dir=$1
+  local go_dir
 
   if [[ ! -f $bp_dir/bin/resolve-version ]]; then
     log_info "Bootstrapping buildpack"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -157,8 +157,8 @@ write_launch_toml() {
   fi
 
   if [[ ! $command ]]; then
-    echo "No file to start server"
-    echo "either use 'docker run' to start container or add index.js or server.js"
+    log_info "No file to start server"
+    log_info "either use 'docker run' to start container or add index.js or server.js"
   else
     cat <<TOML > "$launch_toml"
 [[processes]]

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -146,7 +146,7 @@ write_launch_toml() {
   local build_dir=$1
   local launch_toml=$2
 
-  local command
+  local command=1
 
   if [[ -f "$build_dir/server.js" ]]; then
     command="node server.js"
@@ -156,7 +156,7 @@ write_launch_toml() {
     command="node index.js"
   fi
 
-  if [[ ! $command ]]; then
+  if [[ "$command" == 1 ]]; then
     log_info "No file to start server"
     log_info "either use 'docker run' to start container or add index.js or server.js"
   else

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -146,7 +146,7 @@ write_launch_toml() {
   local build_dir=$1
   local launch_toml=$2
 
-  local command=1
+  local command
 
   if [[ -f "$build_dir/server.js" ]]; then
     command="node server.js"
@@ -156,7 +156,7 @@ write_launch_toml() {
     command="node index.js"
   fi
 
-  if [[ "$command" == 1 ]]; then
+  if [[ ! "$command" ]]; then
     log_info "No file to start server"
     log_info "either use 'docker run' to start container or add index.js or server.js"
   else

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -43,7 +43,7 @@ describe "lib/build.sh"
 
   describe "boostrap_buildpack"
     create_binaries "$layers_dir/bootstrap"
-    
+
     it "does not write to bin"
       assert file_absent "bin/resolve-version"
     end

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -1,4 +1,4 @@
-set -eu
+set -e
 set -o pipefail
 
 source "./lib/utils/json.sh"

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -1,4 +1,4 @@
-set -e
+set -eu
 set -o pipefail
 
 source "./lib/utils/json.sh"


### PR DESCRIPTION
# Description

The `bin/build` script is run with the `-u` flag, which will raise an error in the bash script and exit the build.

This may be unexpected behavior, so I'm going to remove the flag. The unit test suite did not use the flag, so the tests were passing when pulling in methods and using unbound variables.

I first added the flag to the unit test to confirm that this was the issue (tests failed), then I went to assign the variable to a value to appease the error - I removed this though because I didn't want the code to use the flag when the tests don't, so I removed the flag from `bin/build`.

Would like to get some other opinions though in case this is not desired behavior.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
