### PR TITLE
Dockerize unit tests locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ services:
 - docker
 go:
 - 1.12.x
-before_install:
-- curl -sLo- http://get.bpkg.sh | sudo bash
-before_script:
-- sudo bpkg install rylnd/shpec
 script:
 - make test
 - make package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master
 - Add shpec to shellcheck ([#38](https://github.com/heroku/nodejs-engine-buildpack/pull/38))
+- Dockerize unit tests with shpec ([#39](https://github.com/heroku/nodejs-engine-buildpack/pull/39))
 
 ## 0.4.3 (2020-02-24)
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ VERSION := "v$$(cat buildpack.toml | grep version | sed -e 's/version = //g' | x
 test:
 	make shellcheck
 	make binary-test
-	make unit-test
+	make docker-unit-test
+
+docker-unit-test:
+	@docker run -v $(PWD):/project danielleadams/shpec:latest
 
 unit-test:
 	shpec ./shpec/*_shpec.sh

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ brew install pack
 
 If you're using Windows or Linux, follow instructions [here](https://buildpacks.io/docs/install-pack/).
 
-### Install shpec
+### Install shpec (optional)
 
 This buildpack uses `shpec` for unit tests, so to run them locally, you'll need to install the package.
 
@@ -59,7 +59,7 @@ make build-local
 
 ## Testing
 
-Make sure `shpec` is installed. Then, the test script can be run.
+The complete test suite needs Docker to run. Make sure to [install Docker first](https://hub.docker.com/search?type=edition&offering=community).
 
 ```sh
 make test
@@ -69,6 +69,8 @@ If you want to run individual test suites, that's available too.
 
 **Unit Tests**
 
+To run the tests on the local host, [make sure `shpec` is installed](#install-shpec-optional).
+
 ```sh
 make unit-test
 ```
@@ -77,6 +79,30 @@ make unit-test
 
 ```sh
 make binary-tests
+```
+
+### Unit tests in Docker
+
+Running the `shpec` aren't ideal since the test scripts read and write to the local buildpack directory, so Docker may be preferred.
+
+As suggested above, install [Docker](#testing). Next, run the tests with the Make script:
+
+```sh
+make docker-unit-test
+```
+
+### Debugging tests
+
+To debug, make changes from the code and rerun with the make command. To see what is happening, I suggest wrapping code blocks in question with `set -x`/`set +x`. It would look like this in the shpec file:
+
+```sh
+set -x
+it "creates a toolbox.toml"
+  install_or_reuse_toolbox "$layers_dir/toolbox"
+
+  assert file_present "$layers_dir/toolbox.toml"
+end
+set +x
 ```
 
 ## Contributing


### PR DESCRIPTION
# Description

Dockerizes the unit tests that are run with shpec locally. The next step will be to move this to use the dockerized tests in CI, but for now this just makes locally development/unit testing easier.

# Checklist:

- [x] Run these changes with `pack`
- [x] Update `README.md`
- [x] Make updates to `CHANGELOG.md`
