### PR TITLE
Check if resolve-version binary is built before bootstrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add shpec to shellcheck ([#38](https://github.com/heroku/nodejs-engine-buildpack/pull/38))
 - Dockerize unit tests with shpec ([#39](https://github.com/heroku/nodejs-engine-buildpack/pull/39))
 - Upgrade Go version to 1.14 ([#40](https://github.com/heroku/nodejs-engine-buildpack/pull/40))
+- Use cached bootstrap binaries when present ([#42](https://github.com/heroku/nodejs-engine-buildpack/pull/42))
 
 ## 0.4.3 (2020-02-24)
 ### Fixed

--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -14,7 +14,7 @@ install_go() {
 
   go_tgz="$(mktemp /tmp/go.tgz.XXXXXX)"
 
-  curl --retry 3 -sf -o "$go_tgz" -L https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz
+  curl --retry 3 -sf -o "$go_tgz" -L https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz
   tar -C "$go_dir" -xzf "$go_tgz"
 }
 

--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -36,22 +36,26 @@ create_bootstrap_layer() {
 }
 
 bootstrap_buildpack() {
-  local layer_dir=$1
+  local layer_dir="$1"
   local go_dir
 
-  if [[ ! -f $bp_dir/bin/resolve-version ]]; then
-    log_info "Bootstrapping buildpack"
-
-    go_dir="$(mktemp -d)"
-    install_go "$go_dir"
-    export PATH="$PATH:${go_dir}/go/bin"
-
-    cd "$bp_dir"
-
-    create_bootstrap_layer "$layer_dir"
-    build_cmd "resolve-version" "$layer_dir"
-    export PATH=$layer_dir/bin:$PATH
-  else
+  if [[ -f "$bp_dir/bin/resolve-version" ]]; then
     export PATH=$bp_dir/bin:$PATH
+  else
+    if [[ -f "$layer_dir/bin/resolve-version" ]]; then
+      log_info "Using previously bootstrapped binaries"
+    else
+      log_info "Bootstrapping buildpack"
+
+      go_dir="$(mktemp -d)"
+      install_go "$go_dir"
+      export PATH="$PATH:${go_dir}/go/bin"
+
+      cd "$bp_dir"
+
+      create_bootstrap_layer "$layer_dir"
+      build_cmd "resolve-version" "$layer_dir"
+    fi
+    export PATH=$layer_dir/bin:$PATH
   fi
 }


### PR DESCRIPTION
# Description

This PR bumps the Go version that is downloaded if bootstrapping is needed. It also adds a check to check the layers if it needs to rebuild the binaries.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
