### PR TITLE
Extend the MaxKeys param for the heroku-nodebin S3 bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+- Increase `MaxKeys` for listing S3 objects in `resolve-version` query ([#43](https://github.com/heroku/nodejs-engine-buildpack/pull/43))
 
 ## 0.4.4 (2020-03-25)
 ### Added

--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -275,6 +275,7 @@ func fetchS3Result(bucketName string, region string, options map[string]string) 
 	var result result
 	v := url.Values{}
 	v.Set("list-type", "2")
+	v.Set("max-keys", "2000")
 	for key, val := range options {
 		v.Set(key, val)
 	}


### PR DESCRIPTION
# Description

By default, the `MaxKeys` param for listing objects in a public S3 bucket is 1000. The current `KeyCount` for the `node` folder is 962 at the time of this commit. This should buy us more headroom for a longer term solution.

The is the new full URL to query for node objects: <https://heroku-nodebin.s3.us-east-1.amazonaws.com/?prefix=node&list-type=2&max-keys=2000>

# Checklist:

- [ ] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
