### PR TITLE
Remove detect check for package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Fixed
+- Remove check for package.json in bin/detect (always pass detection)
 
 ## 0.4.4 (2020-03-25)
 ### Added

--- a/bin/detect
+++ b/bin/detect
@@ -4,14 +4,9 @@ set -eo pipefail
 
 # shellcheck disable=SC2128
 bp_dir=$(cd "$(dirname "$0")/.."; pwd)
-build_dir=$(pwd)
 build_plan="$2"
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
-if ! detect_package_json "$build_dir" ; then
-  exit 100
-else
-  write_to_build_plan "$build_plan"
-fi
+write_to_build_plan "$build_plan"

--- a/shpec/detect_shpec.sh
+++ b/shpec/detect_shpec.sh
@@ -11,7 +11,7 @@ create_temp_project_dir() {
 
 describe "lib/detect.sh"
   describe "detect_package_json"
-    it "exits with 1 if there is no package.json"
+    it "exits with 0 if there is no package.json"
       project_dir=$(create_temp_project_dir)
 
       set +e
@@ -19,7 +19,7 @@ describe "lib/detect.sh"
       loc_var=$?
       set -e
 
-      assert equal "$loc_var" 1
+      assert equal "$loc_var" 0
     end
 
     it "exits with 0 if there is package.json"


### PR DESCRIPTION
# Description

The change allows the Node.js engine to be used with apps that do not have a `package.json`. This necessary for tools like [Gradle Node Plugin](https://github.com/node-gradle/gradle-node-plugin).

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
