### PR TITLE
add unit tests per heroku stack, integration tests, and circle ci config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+jobs:
+  unit-test-heroku-stack:
+    parameters:
+      stack:
+        type: "string"
+        default: "heroku-20"
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Shpec unit tests on <<parameters.stack>>
+          command: make unit-test-<<parameters.stack>>
+workflows:
+  version: 2
+  run-unit-tests:
+    jobs:
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-20"
+          stack: "heroku-20"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-18"
+          stack: "heroku-18"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-16"
+          stack: "heroku-16"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,57 @@
 version: 2.1
+orbs:
+  shellcheck: circleci/shellcheck@1.3.16
+  pack: buildpacks/pack@0.1.4
 jobs:
+  integration-test-nodejs-buildpacks:
+    machine: true
+    steps:
+      - pack/install-pack
+      - checkout
+      - run:
+          name: "Download project code"
+          command: git clone git@github.com:danielleadams/typescript-getting-started.git
+      - run:
+          name: "Set pack builder"
+          command: pack set-default-builder heroku/buildpacks:18
+      - run:
+          name: "Build OCI image with NPM and TypeScript buildpacks"
+          command:
+            pack build circle-build-1
+              --buildpack .
+              --buildpack heroku/nodejs-npm
+              --buildpack heroku/nodejs-typescript
+              --path ./typescript-getting-started
+      - run:
+          name: "Test image"
+          command: docker run circle-build-1 "node -v"
   unit-test-heroku-stack:
     parameters:
       stack:
         type: "string"
         default: "heroku-20"
-    machine:
-      docker_layer_caching: true
+    docker:
+      - image: "danielleadams/shpec-<<parameters.stack>>:latest"
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Shpec unit tests on <<parameters.stack>>
-          command: make unit-test-<<parameters.stack>>
+          command: make unit-test
+  unit-test-binary:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Run unit tests for Go
+          command: go test ./... -tags=integration
 workflows:
   version: 2
-  run-unit-tests:
+  run-tests:
     jobs:
       - unit-test-heroku-stack:
           name: "Unit tests for heroku-20"
@@ -25,3 +62,8 @@ workflows:
       - unit-test-heroku-stack:
           name: "Unit tests for heroku-16"
           stack: "heroku-16"
+      - unit-test-binary:
+          name: "Unit tests for Go binaries"
+      - shellcheck/check
+      - integration-test-nodejs-buildpacks:
+          name: "Integration tests with Heroku Node.js buildpacks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## master
 - Increase `MaxKeys` for listing S3 objects in `resolve-version` query ([#43](https://github.com/heroku/nodejs-engine-buildpack/pull/43))
+- Add Circle CI test integration ([#49](https://github.com/heroku/nodejs-engine-buildpack/pull/49))
 
 ## 0.4.4 (2020-03-25)
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ test:
 	make binary-test
 	make docker-unit-test
 
+unit-test-heroku-20:
+	@docker run -v $(PWD):/project danielleadams/shpec:latest
+
+unit-test-heroku-18:
+	@docker run -v $(PWD):/project danielleadams/shpec-heroku-18:latest
+
+unit-test-heroku-16:
+	@docker run -v $(PWD):/project danielleadams/shpec-heroku-16:latest
+
 docker-unit-test:
 	@docker run -v $(PWD):/project danielleadams/shpec:latest
 


### PR DESCRIPTION
# Description

This adds more automation to buildpack testing. We can test integrations between buildpacks (ie. engine <--> npm and npm <--> typescript) without having to manually test. Still some work to be done, but this is the first pull request.

Follow ups:
- Move some of the pack stuff into the pack orb
- Create circle integration for NPM
- Create a better testing code base for `pack build`

Note: This pull request also adds division of testing against Heroku stacks.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
