### PR TITLE
set node_env to production during runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 - Add profile.d script ([#53](https://github.com/heroku/nodejs-engine-buildpack/pull/53))
+- Set NODE_ENV to production at runtime ([#54](https://github.com/heroku/nodejs-engine-buildpack/pull/54))
 
 ## 0.5.0 (2020-07-16)
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -36,6 +36,8 @@ if [[ -f "yarn.lock" ]]; then
 	export PATH=$layers_dir/yarn/bin:$PATH
 fi
 
+set_node_env "$layers_dir/nodejs"
+
 copy_profile "$layers_dir/nodejs" "$bp_dir"
 
 write_launch_toml "$build_dir" "$layers_dir/launch.toml"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -144,10 +144,11 @@ install_or_reuse_yarn() {
 
 set_node_env() {
   local layer_dir=$1
+  local node_env=${NODE_ENV:-production}
 
   mkdir -p "${layer_dir}/env.launch"
   if [[ ! -s "${layer_dir}/env.launch/NODE_ENV" ]]; then
-    echo "production" >> "${layer_dir}/env.launch/NODE_ENV"
+    echo "$node_env" >> "${layer_dir}/env.launch/NODE_ENV"
   fi
 }
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -142,6 +142,15 @@ install_or_reuse_yarn() {
   fi
 }
 
+set_node_env() {
+  local layer_dir=$1
+
+  mkdir -p "${layer_dir}/env.launch"
+  if [[ ! -s "${layer_dir}/env.launch/NODE_ENV" ]]; then
+    echo "production" >> "${layer_dir}/env.launch/NODE_ENV"
+  fi
+}
+
 copy_profile() {
   local layer_dir=$1
   local bp_dir=$2

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -141,12 +141,26 @@ describe "lib/build.sh"
 
   describe "set_node_env"
     layers_dir=$(create_temp_layer_dir)
-    it "sets NODE_ENV to production"
+    it "sets env.launch/NODE_ENV to production when NODE_ENV is blank"
       assert file_absent "$layers_dir/nodejs/env.launch/NODE_ENV"
 
       set_node_env "$layers_dir/nodejs"
 
       assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV"
+      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV")" production
+
+      rm "$layers_dir/nodejs/env.launch/NODE_ENV"
+    end
+
+    it "sets env.launch/NODE_ENV to NODE_ENV"
+      export NODE_ENV="test"
+
+      set_node_env "$layers_dir/nodejs"
+
+      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV"
+      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV")" test
+
+      unset NODE_ENV
     end
 
     rm_temp_dirs "$layers_dir"

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -139,6 +139,19 @@ describe "lib/build.sh"
     rm_temp_dirs "$layers_dir"
   end
 
+  describe "set_node_env"
+    layers_dir=$(create_temp_layer_dir)
+    it "sets NODE_ENV to production"
+      assert file_absent "$layers_dir/nodejs/env.launch/NODE_ENV"
+
+      set_node_env "$layers_dir/nodejs"
+
+      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV"
+    end
+
+    rm_temp_dirs "$layers_dir"
+  end
+
   describe "copy_profile"
     layers_dir=$(create_temp_layer_dir)
     it "copies WEB_CONCURRENCY.sh script"


### PR DESCRIPTION
# Description

Unless specified otherwise, we should set NODE_ENV to production at runtime. This will be set in [<layers>/<layer>/env.launch/](https://github.com/buildpacks/spec/blob/main/buildpack.md#build) for launch after `env` and before `profile.d`.

# Checklist:

- [x] Run these changes with `pack`
- [x] Verify env var is set
- [x] Make updates to `CHANGELOG.md`
