### PR TITLE
set NODE_ENV in build env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main
 - Add profile.d script ([#53](https://github.com/heroku/nodejs-engine-buildpack/pull/53))
 - Set NODE_ENV to production at runtime ([#54](https://github.com/heroku/nodejs-engine-buildpack/pull/54))
+- Set NODE_ENV in build environment ([#55](https://github.com/heroku/nodejs-engine-buildpack/pull/55))
 
 ## 0.5.0 (2020-07-16)
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -21,6 +21,8 @@ log_info "Node.js Buildpack"
 
 rm -rf node_modules
 
+set_up_environment "$layers_dir/nodejs"
+
 bootstrap_buildpack "$layers_dir/bootstrap"
 
 install_or_reuse_toolbox "$layers_dir/toolbox"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -12,6 +12,18 @@ source "$bp_dir/lib/utils/log.sh"
 # shellcheck source=/dev/null
 source "$bp_dir/lib/utils/toml.sh"
 
+set_up_environment() {
+  local layer_dir=$1
+  local node_env=${NODE_ENV:-production}
+
+  mkdir -p "${layer_dir}/env.build"
+
+  if [[ ! -s "${layer_dir}/env.build/NODE_ENV" ]]; then
+    echo "$node_env" >> "${layer_dir}/env.build/NODE_ENV"
+  fi
+  log_info "Setting NODE_ENV to ${node_env}"
+}
+
 install_or_reuse_toolbox() {
   local layer_dir=$1
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -19,7 +19,7 @@ set_up_environment() {
   mkdir -p "${layer_dir}/env.build"
 
   if [[ ! -s "${layer_dir}/env.build/NODE_ENV" ]]; then
-    echo "$node_env" >> "${layer_dir}/env.build/NODE_ENV"
+    echo -e "$node_env\c" >> "${layer_dir}/env.build/NODE_ENV"
   fi
   log_info "Setting NODE_ENV to ${node_env}"
 }
@@ -160,7 +160,7 @@ set_node_env() {
 
   mkdir -p "${layer_dir}/env.launch"
   if [[ ! -s "${layer_dir}/env.launch/NODE_ENV" ]]; then
-    echo "$node_env" >> "${layer_dir}/env.launch/NODE_ENV"
+    echo -e "$node_env\c" >> "${layer_dir}/env.launch/NODE_ENV"
   fi
 }
 

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -55,6 +55,33 @@ describe "lib/build.sh"
     end
   end
 
+  describe "set_up_environment"
+    layers_dir=$(create_temp_layer_dir)
+    it "sets env.build/NODE_ENV to production when NODE_ENV is blank"
+      assert file_absent "$layers_dir/nodejs/env.build/NODE_ENV"
+
+      set_up_environment "$layers_dir/nodejs"
+
+      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV"
+      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV")" production
+
+      rm "$layers_dir/nodejs/env.build/NODE_ENV"
+    end
+
+    it "sets env.build/NODE_ENV to NODE_ENV"
+      export NODE_ENV="test"
+
+      set_up_environment "$layers_dir/nodejs"
+
+      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV"
+      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV")" test
+
+      unset NODE_ENV
+    end
+
+    rm_temp_dirs "$layers_dir"
+  end
+
   describe "install_or_reuse_toolbox"
     export PATH=$layers_dir/toolbox/bin:$PATH
 


### PR DESCRIPTION
# Description

NODE_ENV should be set to "production" at the build environment if not already set. Build output should include what NODE_ENV is set to.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
