### PR TITLE
0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
+
+## 0.6.0 (2020-10-13)
+### Added
 - Add profile.d script ([#53](https://github.com/heroku/nodejs-engine-buildpack/pull/53))
 - Set NODE_ENV to production at runtime ([#54](https://github.com/heroku/nodejs-engine-buildpack/pull/54))
 - Set NODE_ENV in build environment ([#55](https://github.com/heroku/nodejs-engine-buildpack/pull/55))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "heroku/nodejs-engine"
 name = "Node Buildpack"
-version = "0.5.0"
+version = "0.6.0"
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
# Description

0.6.0 release:
- Add profile.d script ([#53](https://github.com/heroku/nodejs-engine-buildpack/pull/53))
- Set NODE_ENV to production at runtime ([#54](https://github.com/heroku/nodejs-engine-buildpack/pull/54))
- Set NODE_ENV in build environment ([#55](https://github.com/heroku/nodejs-engine-buildpack/pull/55))

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
