### PR TITLE
remove jq installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
+- Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
 
 ## 0.6.0 (2020-10-13)
 ### Added

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -30,12 +30,6 @@ install_or_reuse_toolbox() {
   log_info "Installing toolbox"
   mkdir -p "${layer_dir}/bin"
 
-  if [[ ! -f "${layer_dir}/bin/jq" ]]; then
-    log_info "- jq"
-    curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > "${layer_dir}/bin/jq" \
-      && chmod +x "${layer_dir}/bin/jq"
-  fi
-
   if [[ ! -f "${layer_dir}/bin/yj" ]]; then
     log_info "- yj"
     curl -Ls https://github.com/sclevine/yj/releases/download/v2.0/yj-linux > "${layer_dir}/bin/yj" \

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -88,7 +88,6 @@ describe "lib/build.sh"
     it "creates a toolbox layer"
       install_or_reuse_toolbox "$layers_dir/toolbox"
 
-      assert file_present "$layers_dir/toolbox/bin/jq"
       assert file_present "$layers_dir/toolbox/bin/yj"
     end
 


### PR DESCRIPTION
# Description

It's been added to the stack image, so we don't need to install it anymore.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
