### PR TITLE
Support heroku 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   shellcheck: circleci/shellcheck@1.3.16
   pack: buildpacks/pack@0.2.0
 jobs:
-  ntegration-test-nodejs-buildpacks:
+  integration-test-nodejs-buildpacks:
     parameters:
       stack-number:
         type: "string"
@@ -71,7 +71,4 @@ workflows:
       - shellcheck/check
       - integration-test-nodejs-buildpacks:
           name: "Integration tests for heroku-18 with Heroku Node.js buildpacks"
-          stack-name: "18"
-      - integration-test-nodejs-buildpacks:
-          name: "Integration tests for heroku-20 with Heroku Node.js buildpacks"
-          stack-name: "20"
+          stack-number: "18"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2.1
 orbs:
   shellcheck: circleci/shellcheck@1.3.16
-  pack: buildpacks/pack@0.1.4
+  pack: buildpacks/pack@0.2.0
 jobs:
-  integration-test-nodejs-buildpacks:
+  ntegration-test-nodejs-buildpacks:
+    parameters:
+      stack-number:
+        type: "string"
+        default: "20"
     machine: true
     steps:
       - pack/install-pack
@@ -13,7 +17,7 @@ jobs:
           command: git clone git@github.com:danielleadams/typescript-getting-started.git
       - run:
           name: "Set pack builder"
-          command: pack set-default-builder heroku/buildpacks:18
+          command: pack set-default-builder heroku/buildpacks:<<parameters.stack-number>>
       - run:
           name: "Build OCI image with NPM and TypeScript buildpacks"
           command:
@@ -66,4 +70,8 @@ workflows:
           name: "Unit tests for Go binaries"
       - shellcheck/check
       - integration-test-nodejs-buildpacks:
-          name: "Integration tests with Heroku Node.js buildpacks"
+          name: "Integration tests for heroku-18 with Heroku Node.js buildpacks"
+          stack-name: "18"
+      - integration-test-nodejs-buildpacks:
+          name: "Integration tests for heroku-20 with Heroku Node.js buildpacks"
+          stack-name: "20"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 - Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
+- Add support for heroku-20 ([#60](https://github.com/heroku/nodejs-engine-buildpack/pull/60))
 
 ## 0.6.0 (2020-10-13)
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -4,8 +4,7 @@ set -o pipefail
 
 layers_dir=$1
 
-# shellcheck disable=SC2128
-bp_dir=$(cd "$(dirname "$0")/.."; pwd)
+bp_dir="$CNB_BUILDPACK_DIR"
 build_dir=$(pwd)
 
 # shellcheck source=/dev/null

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,4 +9,7 @@ version = "0.6.0"
 id = "heroku-18"
 
 [[stacks]]
+id = "heroku-20"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heroku/node-js-cnb
+module github.com/heroku/nodejs-engine-buildpack
 
 go 1.14
 


### PR DESCRIPTION
# Description

Add support for heroku-20. Includes adding to the 'buildpack.toml' and stack parameters for integration tests to be used once the buidpacks are updated on the Heroku builder.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
