### PR TITLE
Make the NODE_ENV variables overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main
 - Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
 - Add support for heroku-20 ([#60](https://github.com/heroku/nodejs-engine-buildpack/pull/60))
-- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61))
+- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61)) 
 
 ## 0.6.0 (2020-10-13)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 - Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
+- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61))
 
 ## 0.6.0 (2020-10-13)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main
 - Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
 - Add support for heroku-20 ([#60](https://github.com/heroku/nodejs-engine-buildpack/pull/60))
-- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61)) 
+- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61))
 
 ## 0.6.0 (2020-10-13)
 ### Added

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -18,8 +18,8 @@ set_up_environment() {
 
   mkdir -p "${layer_dir}/env.build"
 
-  if [[ ! -s "${layer_dir}/env.build/NODE_ENV" ]]; then
-    echo -e "$node_env\c" >> "${layer_dir}/env.build/NODE_ENV"
+  if [[ ! -s "${layer_dir}/env.build/NODE_ENV.override" ]]; then
+    echo -e "$node_env\c" >> "${layer_dir}/env.build/NODE_ENV.override"
   fi
   log_info "Setting NODE_ENV to ${node_env}"
 }
@@ -153,8 +153,8 @@ set_node_env() {
   local node_env=${NODE_ENV:-production}
 
   mkdir -p "${layer_dir}/env.launch"
-  if [[ ! -s "${layer_dir}/env.launch/NODE_ENV" ]]; then
-    echo -e "$node_env\c" >> "${layer_dir}/env.launch/NODE_ENV"
+  if [[ ! -s "${layer_dir}/env.launch/NODE_ENV.override" ]]; then
+    echo -e "$node_env\c" >> "${layer_dir}/env.launch/NODE_ENV.override"
   fi
 }
 

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -57,24 +57,24 @@ describe "lib/build.sh"
 
   describe "set_up_environment"
     layers_dir=$(create_temp_layer_dir)
-    it "sets env.build/NODE_ENV to production when NODE_ENV is blank"
-      assert file_absent "$layers_dir/nodejs/env.build/NODE_ENV"
+    it "sets env.build/NODE_ENV.override to production when NODE_ENV is blank"
+      assert file_absent "$layers_dir/nodejs/env.build/NODE_ENV.override"
 
       set_up_environment "$layers_dir/nodejs"
 
-      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV"
-      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV")" production
+      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV.override"
+      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV.override")" production
 
-      rm "$layers_dir/nodejs/env.build/NODE_ENV"
+      rm "$layers_dir/nodejs/env.build/NODE_ENV.override"
     end
 
-    it "sets env.build/NODE_ENV to NODE_ENV"
+    it "sets env.build/NODE_ENV.override to NODE_ENV"
       export NODE_ENV="test"
 
       set_up_environment "$layers_dir/nodejs"
 
-      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV"
-      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV")" test
+      assert file_present "$layers_dir/nodejs/env.build/NODE_ENV.override"
+      assert equal "$(cat "$layers_dir/nodejs/env.build/NODE_ENV.override")" test
 
       unset NODE_ENV
     end
@@ -167,24 +167,24 @@ describe "lib/build.sh"
 
   describe "set_node_env"
     layers_dir=$(create_temp_layer_dir)
-    it "sets env.launch/NODE_ENV to production when NODE_ENV is blank"
-      assert file_absent "$layers_dir/nodejs/env.launch/NODE_ENV"
+    it "sets env.launch/NODE_ENV.override to production when NODE_ENV is blank"
+      assert file_absent "$layers_dir/nodejs/env.launch/NODE_ENV.override"
 
       set_node_env "$layers_dir/nodejs"
 
-      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV"
-      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV")" production
+      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV.override"
+      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV.override")" production
 
-      rm "$layers_dir/nodejs/env.launch/NODE_ENV"
+      rm "$layers_dir/nodejs/env.launch/NODE_ENV.override"
     end
 
-    it "sets env.launch/NODE_ENV to NODE_ENV"
+    it "sets env.launch/NODE_ENV.override to NODE_ENV"
       export NODE_ENV="test"
 
       set_node_env "$layers_dir/nodejs"
 
-      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV"
-      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV")" test
+      assert file_present "$layers_dir/nodejs/env.launch/NODE_ENV.override"
+      assert equal "$(cat "$layers_dir/nodejs/env.launch/NODE_ENV.override")" test
 
       unset NODE_ENV
     end


### PR DESCRIPTION
# Description

#54 and #55 set new build/launch ENV files. Over in the Cloud Native Buildpack world, [the specification recently had the `prepend` action as default](https://github.com/buildpacks/spec/blob/buildpack/0.4/buildpack.md#environment-variable-modification-rules). It's been [changed to `override`](https://github.com/buildpacks/spec/issues/131), but that hasn't made its way into the implementation yet nor would that be used by this project, as it's on API 0.2. 

As such, this results in containers with an externally set `NODE_ENV` producing output like this:

```sh
$ echo $NODE_ENV
production

$ /cnb/lifecycle/launcher 'echo $NODE_ENV'
production:production
```

This PR switches the files to explicitly use the `override` action. Pretty simple, but I'm not sure how this works internally in Heroku, so this may break things on that end in a way I'm unable to test.

I hope that makes sense. Let me know if I can clarify anything. 

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
