### PR TITLE
configure only tags and release publish to run action

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,3 +1,8 @@
+name: "Release Buildpack Image"
+on:
+  release:
+    types:
+      - published
 jobs:
   create-package:
     name: "Package, Publish, and Register"
@@ -49,8 +54,3 @@ jobs:
           id: heroku/procfile
           token: "${{ secrets.PUBLIC_REPO_TOKEN }}"
           version: "${{ steps.package.outputs.version }}"
-name: "Release Buildpack Image"
-true:
-  release:
-    types:
-      - published


### PR DESCRIPTION
Continuation of https://github.com/heroku/nodejs-engine-buildpack/pull/67