### PR TITLE
remove package.json requirement and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## main
 - Replace logging style to match style guides ([#63](https://github.com/heroku/nodejs-engine-buildpack/pull/63))
 - Change log colors to use ANSI codes ([#65](https://github.com/heroku/nodejs-engine-buildpack/pull/65))
+- Remove package.json requirement ([#69](https://github.com/heroku/nodejs-engine-buildpack/pull/69))
 
 ## 0.7.0 (2020-11-11)
 ### Added

--- a/bin/detect
+++ b/bin/detect
@@ -4,7 +4,6 @@ set -eo pipefail
 
 # shellcheck disable=SC2128
 bp_dir=$(cd "$(dirname "$0")/.."; pwd)
-build_dir=$(pwd)
 build_plan="$2"
 
 # shellcheck source=/dev/null

--- a/bin/detect
+++ b/bin/detect
@@ -10,8 +10,4 @@ build_plan="$2"
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
-if ! detect_package_json "$build_dir" ; then
-  exit 100
-else
-  write_to_build_plan "$build_plan"
-fi
+write_to_build_plan "$build_plan"

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-detect_package_json() {
-  local build_dir=$1
-  [[ -f "$build_dir/package.json" ]]
-}
-
 write_to_build_plan() {
   local build_plan=$1
   cat << EOF > "$build_plan"

--- a/shpec/detect_shpec.sh
+++ b/shpec/detect_shpec.sh
@@ -10,28 +10,6 @@ create_temp_project_dir() {
 }
 
 describe "lib/detect.sh"
-  describe "detect_package_json"
-    it "exits with 1 if there is no package.json"
-      project_dir=$(create_temp_project_dir)
-
-      set +e
-      detect_package_json "$project_dir"
-      loc_var=$?
-      set -e
-
-      assert equal "$loc_var" 1
-    end
-
-    it "exits with 0 if there is package.json"
-      project_dir=$(create_temp_project_dir)
-      touch "$project_dir/package.json"
-
-      detect_package_json "$project_dir"
-
-      assert equal "$?" 0
-    end
-  end
-
   describe "write_to_build_plan"
     it "writes node for [[provides]] and [[requires]]"
       project_dir=$(create_temp_project_dir)


### PR DESCRIPTION
# Description

Remove package.json requirement to fix downstream buildpack issues for builds that need the Node runtime, but that may not have a package.json.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
